### PR TITLE
Add Shattered Planet mod support

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -7,7 +7,8 @@ include_files = {
     "*.lua",
     "scripts/**/*.lua",
     "spec/**/*.lua",
-    "tasks/**/*.lua"
+    "tasks/**/*.lua",
+    "migrations/**/*.lua"
 }
 
 std = "lua52c"


### PR DESCRIPTION
Shattered Planet by CPU_BlackHeart https://mods.factorio.com/mod/skewer_shattered_planet

This mod adds a new lab `pearl_realizer` which uses graphic assets from space-exploration.

- Maybe we can use a light layer as-is for colorization.
- But, it has really dynamic animation, and the overlay should be sync-ed with the animation.
