### PR TITLE
Add e2e (end-to-end) tests by factorio-test

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,6 +41,7 @@ This mod provides users with:
     - `make mod-description`: Updates the [mod description](/docs/mod-portal/description.md)
     - `make lint`: Lints codes by `luacheck`
     - `make test`: Runs unit tests by `busted`
+    - `make test-e2e`: Runs end-to-end tests by `factorio-test`
 - `make full-check`: Runs following: (approx. 30 seconds to run)
     - `make check`
     - `make typecheck`: Type-checks by lua-language-server, and checks [disco-science-lite.d.ts](/disco-science-lite.d.ts) by `tsc`

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,8 @@ __pycache__/
 /.venv
 /.ruff_cache
 
+/node_modules
+
+/e2e/factorio-test-data-dir
+
 /tasks/check-updates/.downloaded

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -7,12 +7,26 @@ include_files = {
     "*.lua",
     "scripts/**/*.lua",
     "spec/**/*.lua",
+    "e2e/**/*.lua",
     "tasks/**/*.lua",
     "migrations/**/*.lua"
 }
+exclude_files = {
+    "e2e/factorio-test-data-dir/**",
+    "e2e/factorio-test.def.lua"
+}
 
 std = "lua52c"
+
 files["spec/**/*_spec.lua"] = { std = "lua52+busted" }
+
+files["e2e/*.lua"] = {
+    std = "lua52+busted",
+    globals = {
+        "test",
+        "after_ticks"
+    }
+}
 
 globals = {
     "script",

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ lint:
 test:
 	@busted
 
+test-e2e:
+	@npx factorio-test run -p .
+
 consts:
 	@lua tasks/update-consts.lua
 
@@ -24,7 +27,7 @@ mod-description:
 mods:
 	@tasks/update-all-mods.sh
 
-check: consts mods mod-description lint test
+check: consts mods mod-description lint test test-e2e
 
 typecheck:
 	@tsc -p tasks/typecheck/tsconfig.json

--- a/control.lua
+++ b/control.lua
@@ -13,3 +13,14 @@ if Settings.is_development then
   require("scripts.runtime.command.ds-showcase")
   require("scripts.runtime.command.ds-test")
 end
+
+if script.active_mods["factorio-test"] then
+  require("__factorio-test__/init")(
+    {
+      "e2e.lab-overlay_test",
+    },
+    {
+      load_luassert = true,
+    }
+  )
+end

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ This project's directory (or its symlink) should be located in the `mods` direct
 
 ## Dependencies
 
-To install dependencies by luarocks:
+To install Lua dependencies by luarocks:
 
 ```
 make dev
@@ -26,9 +26,15 @@ If you have installed `pcre2` with Homebrew at `/opt/homebrew`:
 make dev C_INCLUDE_PATH=/opt/homebrew/include LIBRARY_PATH=/opt/homebrew/lib
 ```
 
+To install Node.js dependencies by npm:
+
+```
+npm install
+```
+
 ## Tests
 
-To run unit tests, lint, typecheck:
+To run tests, lint, typecheck:
 
 ```
 make check
@@ -40,6 +46,7 @@ This does:
 - `make mods`: Updates the [mod load list](/scripts/prototype/mods/_all.lua).
 - `make lint`: Lints codes by `luacheck`
 - `make test`: Runs unit tests by `busted`
+- `make test-e2e`: Runs end-to-end tests by `factorio-test`
 - `make typecheck`: Type-checks [disco-science-lite.d.ts](/disco-science-lite.d.ts) by `tsc`
 
 ## Special Constants Syntax

--- a/e2e/factorio-test.def.lua
+++ b/e2e/factorio-test.def.lua
@@ -1,0 +1,106 @@
+--- @meta
+--- This is copied from the FactorioTest repository, and modified for LuaLS.
+--- https://github.com/GlassBricks/FactorioTest/blob/main/factorio-test.def.lua
+
+--- @type TestCreator
+test = nil
+--- @type TestCreator
+it = nil
+--- @type DescribeCreator
+describe = nil
+--- @type LifecycleFn
+before_all = nil
+--- @type LifecycleFn
+after_all = nil
+--- @type LifecycleFn
+before_each = nil
+--- @type LifecycleFn
+after_each = nil
+--- @type LifecycleFn
+after_test = nil
+
+--- @param timeout number|nil
+--- @overload fun()
+function async(timeout) end
+
+function done() end
+
+--- @param func OnTickFn
+function on_tick(func) end
+
+--- @param ticks number
+--- @param func TestFn
+function after_ticks(ticks, func) end
+
+--- @param ticks number
+function ticks_between_tests(ticks) end
+
+--- @vararg string
+function tags(...) end
+
+--- @class FactorioTestConfig
+--- @field default_timeout number | nil
+--- @field default_ticks_between_tests number | nil
+--- @field game_speed number | nil
+--- @field log_passed_tests boolean | nil
+--- @field log_skipped_tests boolean | nil
+--- @field test_pattern string | nil
+--- @field tag_whitelist string[] | nil
+--- @field tag_blacklist string[] | nil
+--- @field before_test_run fun() | nil
+--- @field after_test_run fun() | nil
+--- @field sound_effects boolean | nil
+
+--- @alias TestFn fun()
+--- @alias HookFn TestFn
+--- @alias OnTickFn (fun(tick: number)) | (fun(tick: number): boolean)
+
+--- @class TestCreatorBase
+--- @overload fun(name: string, func: TestFn): TestBuilder<TestFn>
+local TestCreatorBase = {}
+
+--- @generic T
+--- @param values T[][]
+--- @return fun(name: string, func: fun(...: T))
+--- @overload fun<T>(values: T[]): fun(name: string, func: fun(v: T))
+function TestCreatorBase.each(values) end
+
+--- @class TestCreator : TestCreatorBase
+--- @overload fun(name: string, func: TestFn): TestBuilder<TestFn>
+--- @field skip TestCreatorBase
+--- @field only TestCreatorBase
+local TestCreator = {
+  --- @param name string
+  todo = function (name)
+  end,
+}
+
+--- @class TestBuilder<T>
+local TestBuilder = {}
+
+--- @generic T
+--- @param func T
+--- @return TestBuilder<T>
+function TestBuilder.after_script_reload(func) end
+
+--- @generic T
+--- @param func T
+--- @return TestBuilder<T>
+function TestBuilder.after_mod_reload(func) end
+
+--- @class DescribeCreatorBase
+--- @overload fun(name: string, func: TestFn)
+local DescribeCreatorBase = {}
+
+--- @generic T
+--- @param values T[][]
+--- @return fun(name: string, func: fun(...: T))
+--- @overload fun<T>(values: T[]): fun(name: string, func: fun(v: T))
+function DescribeCreatorBase.each(values) end
+
+--- @class DescribeCreator : DescribeCreatorBase
+--- @overload fun(name: string, func: TestFn)
+--- @field skip DescribeCreatorBase
+--- @field only DescribeCreatorBase
+
+--- @alias LifecycleFn fun(func: HookFn)

--- a/e2e/lab-overlay_test.lua
+++ b/e2e/lab-overlay_test.lua
@@ -1,0 +1,224 @@
+local LabControl = require("scripts.runtime.control.lab-control")
+local CommandHelpers = require("scripts.runtime.command.command-helpers")
+local Settings = require("scripts.shared.settings")
+local consts = require("scripts.shared.consts")
+local table_merge = require("scripts.shared.utils").table_merge
+--- @module "e2e.factorio-test.def"
+
+describe("LabOverlayRenderer", function ()
+  --- @type LabOverlayRenderer
+  local renderer
+  --- @type LuaSurface
+  local surface
+  --- @type LuaPlayer
+  local player
+
+  before_each(function ()
+    renderer = LabControl.get_renderer()
+    assert(renderer, "LabOverlayRenderer is not initialized")
+    player = game.players[1]
+    surface = player.surface
+    CommandHelpers.setup_test_surface(surface)
+  end)
+
+  test("renders overlay for vanilla lab", function ()
+    local lab = surface.create_entity({
+      name = "lab",
+      position = { x = 0, y = 0 },
+      force = game.forces.player,
+    })
+    assert(lab, "lab entity is not created")
+
+    local overlay = renderer.chunk_map:get(lab.unit_number)
+    assert(overlay, "overlay is not rendered")
+    assert(overlay.entity == lab, "overlay.entity is not lab entity")
+    assert(overlay.animation.valid, "overlay.animation is not valid")
+    assert(overlay.animation.animation == consts.LAB_OVERLAY_ANIMATION_NAME, "overlay.animation name mismatch")
+    assert(overlay.animation.target.entity == lab, "overlay.animation.target is not lab entity")
+    assert(renderer.chunk_map.entries[lab.unit_number], "chunk_map.entries not added")
+    assert(renderer.chunk_map.data[surface.index][0][0][1] == overlay, "chunk_map.data is not updated")
+  end)
+
+  test("removes overlay when lab is destroyed", function ()
+    local lab = surface.create_entity({
+      name = "lab",
+      position = { x = 0, y = 0 },
+      force = game.forces.player,
+    })
+    assert(lab, "lab entity is not created")
+    lab.destroy()
+
+    after_ticks(1, function ()
+      assert(next(renderer.chunk_map.entries) == nil, "chunk_map.entries is not empty after destroy")
+      assert(next(renderer.chunk_map.data) == nil, "chunk_map.data is not empty after destroy")
+      local objects = rendering.get_all_objects(consts.MOD_NAME)
+      assert(#objects == 0, "rendering objects remain after destroy")
+    end)
+  end)
+
+  test("tracks overlays in correct chunks for multiple labs", function ()
+    -- Create labs in different chunks: (0,0), (1,0), (0,1)
+    local lab1 = surface.create_entity({ name = "lab", position = { x = 0, y = 0 }, force = player.force })
+    local lab2 = surface.create_entity({ name = "lab", position = { x = 40, y = 0 }, force = player.force })
+    local lab3 = surface.create_entity({ name = "lab", position = { x = 0, y = 40 }, force = player.force })
+    assert(lab1, "lab1 entity is not created")
+    assert(lab2, "lab2 entity is not created")
+    assert(lab3, "lab3 entity is not created")
+
+    assert(table_size(renderer.chunk_map.entries) == 3, "Expected 3 overlays, got " .. table_size(renderer.chunk_map.entries))
+    assert(renderer.chunk_map:get(lab1.unit_number), "overlay for lab1 not found")
+    assert(renderer.chunk_map:get(lab2.unit_number), "overlay for lab2 not found")
+    assert(renderer.chunk_map:get(lab3.unit_number), "overlay for lab3 not found")
+
+    local entry1 = renderer.chunk_map.entries[lab1.unit_number]
+    local entry2 = renderer.chunk_map.entries[lab2.unit_number]
+    local entry3 = renderer.chunk_map.entries[lab3.unit_number]
+    assert(entry1 and entry1.chunk_x == 0 and entry1.chunk_y == 0, "lab1 not in chunk (0,0)")
+    assert(entry2 and entry2.chunk_x == 1 and entry2.chunk_y == 0, "lab2 not in chunk (1,0)")
+    assert(entry3 and entry3.chunk_x == 0 and entry3.chunk_y == 1, "lab3 not in chunk (0,1)")
+
+    lab1.destroy()
+    lab2.destroy()
+    lab3.destroy()
+
+    after_ticks(1, function ()
+      assert(next(renderer.chunk_map.entries) == nil, "chunk_map.entries is not empty after destroy")
+      assert(next(renderer.chunk_map.data) == nil, "chunk_map.data is not empty after destroy")
+      local objects = rendering.get_all_objects(consts.MOD_NAME)
+      assert(#objects == 0, "rendering objects remain after destroy")
+    end)
+  end)
+
+  test("updates chunk_map when lab is teleported", function ()
+    local lab = surface.create_entity({ name = "lab", position = { x = 0, y = 0 }, force = player.force })
+    assert(lab, "lab entity is not created")
+
+    local entry_before = renderer.chunk_map.entries[lab.unit_number]
+    assert(entry_before, "chunk_map.entries not found before teleport")
+    assert(
+      entry_before.chunk_x == 0 and entry_before.chunk_y == 0,
+      "Expected initial chunk (0,0), got (" .. entry_before.chunk_x .. "," .. entry_before.chunk_y .. ")"
+    )
+
+    -- Teleport to chunk (1,1): position (40, 40) -> floor(40/32) = 1
+    lab.teleport({ 40, 40 }, nil, true)
+
+    after_ticks(1, function ()
+      local entry_after = renderer.chunk_map.entries[lab.unit_number]
+      assert(entry_after, "chunk_map.entries not found after teleport")
+      assert(
+        entry_after.chunk_x == 1 and entry_after.chunk_y == 1,
+        "Expected teleported chunk (1,1), got (" .. entry_after.chunk_x .. "," .. entry_after.chunk_y .. ")"
+      )
+
+      -- Old chunk (0,0) should be gone
+      local surface_chunks = renderer.chunk_map.data[surface.index]
+      assert(not (surface_chunks and surface_chunks[0] and surface_chunks[0][0]), "Old chunk (0,0) still exists in chunk_map")
+
+      lab.destroy()
+    end)
+
+    after_ticks(2, function ()
+      assert(next(renderer.chunk_map.entries) == nil, "chunk_map.entries is not empty after destroy")
+      assert(next(renderer.chunk_map.data) == nil, "chunk_map.data is not empty after destroy")
+      local objects = rendering.get_all_objects(consts.MOD_NAME)
+      assert(#objects == 0, "rendering objects remain after destroy")
+    end)
+  end)
+
+  test("renders overlay on a different surface", function ()
+    local map_gen_settings = table_merge(game.default_map_gen_settings, {
+      width = 32,
+      height = 32,
+      no_enemies_mode = true,
+    })
+    local new_surface = game.create_surface(consts.NAME_PREFIX .. "test-surface", map_gen_settings)
+    CommandHelpers.clear_surface(new_surface)
+
+    local lab = new_surface.create_entity({ name = "lab", position = { x = 0, y = 0 }, force = player.force })
+    assert(lab, "lab entity is not created on new surface")
+    assert(renderer.chunk_map:get(lab.unit_number), "overlay not created for lab on new surface")
+    assert(
+      renderer.chunk_map.entries[lab.unit_number].surface_index == new_surface.index,
+      "overlay surface_index mismatch"
+    )
+
+    new_surface.clear()
+
+    after_ticks(1, function ()
+      assert(next(renderer.chunk_map.entries) == nil, "chunk_map.entries is not empty after surface clear")
+      assert(next(renderer.chunk_map.data) == nil, "chunk_map.data is not empty after surface clear")
+      local objects = rendering.get_all_objects(consts.MOD_NAME)
+      assert(#objects == 0, "rendering objects remain after surface clear")
+
+      game.delete_surface(new_surface)
+    end)
+  end)
+
+  test("applies color to overlay when research is active", function ()
+    local force = player.force
+    local lab = surface.create_entity({ name = "lab", position = { x = 0, y = 0 }, force = force })
+    assert(lab, "lab entity not created")
+    CommandHelpers.fill_lab_entity_with_ingredients(lab)
+    CommandHelpers.set_current_research(force, "automation")
+    player.teleport({ x = 0, y = 0 }, surface)
+    player.zoom = 1.0
+
+    after_ticks(consts.STATE_UPDATE_INTERVAL + 1, function ()
+      local overlay = renderer.chunk_map:get(lab.unit_number)
+      assert(overlay, "overlay not found for lab")
+      assert(
+        overlay.visible,
+        "overlay is not visible (entity.status=" .. tostring(lab.status)
+        .. ", current_research=" .. tostring(force.current_research and force.current_research.name) .. ")"
+      )
+      local color = overlay.animation.color
+      assert(color and (color.r > 0 or color.g > 0 or color.b > 0), "overlay animation color is not set")
+
+      force.cancel_current_research()
+    end)
+  end)
+
+  test("renders overlays for all lab prototypes", function ()
+    local lab_prototypes = prototypes.get_entity_filtered({ { filter = "type", type = "lab" } })
+    local created_labs = {} --- @type LuaEntity[]
+    local x = 0
+    for _, proto in pairs(lab_prototypes) do
+      local lab = surface.create_entity({
+        name = proto.name,
+        position = { x = x, y = 0 },
+        force = player.force,
+      })
+      assert(lab, "Failed to create lab entity: " .. proto.name)
+      created_labs[#created_labs + 1] = lab
+      x = x + proto.tile_width
+    end
+
+    for i = 1, #created_labs do
+      local lab = created_labs[i]
+      local lab_name = lab.name
+      local is_excluded = renderer.lab_registry:is_excluded(lab_name)
+      local has_registration = renderer.lab_registry:get_registration(lab_name) ~= nil
+      local should_have_overlay = not is_excluded and (has_registration or Settings.is_fallback_enabled)
+      if should_have_overlay then
+        local overlay = renderer.chunk_map:get(lab.unit_number)
+        assert(overlay, "overlay not found for lab: " .. lab_name)
+        assert(overlay.animation.valid, "overlay animation not valid for lab: " .. lab_name)
+        assert(renderer.chunk_map.entries[lab.unit_number], "chunk_map entry not found for lab: " .. lab_name)
+      else
+        assert(not renderer.chunk_map:get(lab.unit_number), "excluded lab should not have overlay: " .. lab_name)
+      end
+    end
+
+    for i = 1, #created_labs do
+      created_labs[i].destroy()
+    end
+
+    after_ticks(1, function ()
+      assert(next(renderer.chunk_map.entries) == nil, "chunk_map.entries is not empty after destroy")
+      assert(next(renderer.chunk_map.data) == nil, "chunk_map.data is not empty after destroy")
+      local objects = rendering.get_all_objects(consts.MOD_NAME)
+      assert(#objects == 0, "rendering objects remain after destroy")
+    end)
+  end)
+end)

--- a/factorio-test.json
+++ b/factorio-test.json
@@ -1,0 +1,4 @@
+{
+  "dataDirectory": "e2e/factorio-test-data-dir",
+  "mods": ["base", "elevated-rails", "quality", "space-age"]
+}

--- a/info.json
+++ b/info.json
@@ -18,6 +18,7 @@
     "ignore": [
       ".*",
       "docs/**",
+      "e2e/**",
       "scripts/prototype/mods/*.json",
       "spec/**",
       "tasks/**",
@@ -27,7 +28,11 @@
       "luarocks",
       "Makefile",
       "pyproject.toml",
-      "uv.lock"
+      "uv.lock",
+      "node_modules/**",
+      "package-lock.json",
+      "package.json",
+      "factorio-test.json"
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,372 @@
+{
+  "name": "disco-science-lite",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "disco-science-lite",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "factorio-test-cli": "^3.5.1",
+        "factoriomod-debug": "^2.0.10"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/factorio-test-cli": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/factorio-test-cli/-/factorio-test-cli-3.5.1.tgz",
+      "integrity": "sha512-W9ayQP4+lnBcsVZp0M5keseAwwHHtqxt9Gt1QESLI3luNDajOf17TmoG80rI99kS6MWxREuVMMh/f/niSYTOaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "commander": "^12.1.0",
+        "factoriomod-debug": "^2.0.10",
+        "log-update": "^7.0.2",
+        "minimatch": "^10.1.1",
+        "zod": "^3.24.0"
+      },
+      "bin": {
+        "factorio-test": "cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/factoriomod-debug": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/factoriomod-debug/-/factoriomod-debug-2.0.10.tgz",
+      "integrity": "sha512-UMuf8IIs2YM3vvQim7Kd+A7MuW3b7kTb75tvDCTrRUtU4kWXdtXfPsLN64GE9tKznFE9FOUhCZWeeIEnavpvWQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "factoriomod-debug": "dist/fmtk-cli.js",
+        "fmtk": "dist/fmtk-cli.js"
+      },
+      "engines": {
+        "node": ">=22.7.0",
+        "vscode": "^1.107.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-7.2.0.tgz",
+      "integrity": "sha512-iLs7dGSyjZiUgvrUvuD3FndAxVJk+TywBkkkwUSm9HdYoskJalWg5qVsEiXeufPvRVPbCUmNQewg798rx+sPXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.3.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^8.0.0",
+        "strip-ansi": "^7.2.0",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "disco-science-lite",
+  "version": "1.0.0",
+  "description": "A Factorio mod to colorize Science Labs by their consuming science packs.",
+  "author": "nenshoukei",
+  "license": "MIT",
+  "devDependencies": {
+    "factorio-test-cli": "^3.5.1",
+    "factoriomod-debug": "^2.0.10"
+  }
+}


### PR DESCRIPTION
Fixes #44

Add end-to-end tests using [FactorioTest](https://github.com/GlassBricks/FactorioTest).

Tests are only ported from the [/ds-test](https://github.com/nenshoukei/disco-science-lite/blob/main/scripts/runtime/command/ds-test.lua) command. Not removing the command yet.

- [ ] Requires a fix for the issue https://github.com/GlassBricks/FactorioTest/issues/3
- [ ] Set up CI for the tests